### PR TITLE
Fix wrong Scheduler used for event processing

### DIFF
--- a/src/main/java/space/npstr/magma/AudioStack.java
+++ b/src/main/java/space/npstr/magma/AudioStack.java
@@ -70,7 +70,7 @@ public class AudioStack {
         final UnicastProcessor<LifecycleEvent> lifecycleProcessor = UnicastProcessor.create();
         this.lifecycleSink = lifecycleProcessor.sink();
         this.lifecycleSubscription = lifecycleProcessor
-                .subscribeOn(Schedulers.single())
+                .publishOn(Schedulers.parallel())
                 .subscribe(this::onNext);
     }
 

--- a/src/main/java/space/npstr/magma/AudioStackLifecyclePipeline.java
+++ b/src/main/java/space/npstr/magma/AudioStackLifecyclePipeline.java
@@ -92,7 +92,7 @@ public class AudioStackLifecyclePipeline {
 
         this.lifecycleSubscription = processor
                 .log(log.getName() + ".Inbound", Level.FINEST) //FINEST = TRACE
-                .subscribeOn(Schedulers.single())
+                .publishOn(Schedulers.parallel())
                 .subscribe(this::onEvent);
     }
 

--- a/src/main/java/space/npstr/magma/connections/AudioWebSocket.java
+++ b/src/main/java/space/npstr/magma/connections/AudioWebSocket.java
@@ -158,7 +158,7 @@ public class AudioWebSocket extends BaseSubscriber<InboundWsEvent> {
     private void handleHello(final Hello hello) {
         this.heartbeatSubscription = Flux.interval(Duration.ofMillis(hello.getHeartbeatIntervalMillis()))
                 .doOnNext(tick -> log.trace("Sending heartbeat {}", tick))
-                .subscribeOn(Schedulers.single())
+                .publishOn(Schedulers.parallel())
                 .subscribe(tick -> this.audioWebSocketSink.next(HeartbeatWsEvent.builder()
                         .nonce(tick.intValue())
                         .build())
@@ -187,7 +187,7 @@ public class AudioWebSocket extends BaseSubscriber<InboundWsEvent> {
         log.debug("Selecting encryption mode {}", preferredMode);
 
         this.audioConnection.handleUdpDiscovery(udpTargetAddress, ready.getSsrc())
-                .subscribeOn(Schedulers.single())
+                .publishOn(Schedulers.parallel())
                 .subscribe(externalAddress -> this.audioWebSocketSink.next(
                         SelectProtocolWsEvent.builder()
                                 .protocol("udp")
@@ -239,7 +239,7 @@ public class AudioWebSocket extends BaseSubscriber<InboundWsEvent> {
                     log.error("Exception in websocket connection, closing", t);
                     this.closeEverything();
                 })
-                .subscribeOn(Schedulers.single())
+                .publishOn(Schedulers.parallel())
                 .subscribe();
     }
 

--- a/src/main/java/space/npstr/magma/connections/AudioWebSocketSessionHandler.java
+++ b/src/main/java/space/npstr/magma/connections/AudioWebSocketSessionHandler.java
@@ -65,7 +65,7 @@ public class AudioWebSocketSessionHandler implements WebSocketHandler {
     public void close() {
         if (this.session != null) {
             this.session.close()
-                    .subscribeOn(Schedulers.single())
+                    .publishOn(Schedulers.parallel())
                     .subscribe();
         }
     }
@@ -106,7 +106,7 @@ public class AudioWebSocketSessionHandler implements WebSocketHandler {
                 .log(log.getName() + ".>>>", Level.FINEST) //FINEST = TRACE
                 .map(InboundWsEvent::from)
                 .doOnTerminate(() -> log.trace("Receiving terminated"))
-                .subscribeOn(Schedulers.single())
+                .publishOn(Schedulers.parallel())
                 .subscribe(this.inbound);
 
         return session


### PR DESCRIPTION
The previously used method as well as Scheduler are just plain wrong

- subscribeOn -> publishOn:
Because subscribeOn does not control the event processing down the pipe

- Schedulers.single() -> Schedulers.parallel():
Events are processed one after another without concurrency issues
on either of them. There is no reason to use single (or elastic),
so parallel should be the correct choice.