### PR TITLE
Idempotent handling of VoiceServerUpdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ logging:
 
 Expect breaking changes between minor versions while v1 has not been released.
 
+### v0.8.1
+- Idempotent handling of connection requests [\#16](https://github.com/napstr/Magma/pull/16) (thanks @Frederikam)
+
 ### v0.8.0
 - Add a WebsocketConnectionState to report the state of the websocket connections managed by a MagmaApi
 

--- a/src/main/java/space/npstr/magma/AudioStack.java
+++ b/src/main/java/space/npstr/magma/AudioStack.java
@@ -121,8 +121,8 @@ public class AudioStack extends BaseSubscriber<LifecycleEvent> {
 
         if (this.webSocket != null) {
             if (connectWebSocket.getSessionInfo().equals(connectWebSocket.getSessionInfo())) {
-                log.info("Voice server update was provided, but is identical to the one already used." +
-                        " Refusing to reconnect...");
+                log.info("Discarding received connection request because it is identical to the already existing connection." +
+                        " If you really want to reconnect, send a disconnect request first.");
                 return;
             } else {
                 this.webSocket.close();

--- a/src/main/java/space/npstr/magma/AudioStack.java
+++ b/src/main/java/space/npstr/magma/AudioStack.java
@@ -118,8 +118,15 @@ public class AudioStack extends BaseSubscriber<LifecycleEvent> {
 
     private void handleConnectWebSocket(final ConnectWebSocket connectWebSocket) {
         log.trace("Connecting");
+
         if (this.webSocket != null) {
-            this.webSocket.close();
+            if (connectWebSocket.getSessionInfo().equals(connectWebSocket.getSessionInfo())) {
+                log.info("Voice server update was provided, but is identical to the one already used." +
+                        " Refusing to reconnect...");
+                return;
+            } else {
+                this.webSocket.close();
+            }
         }
 
         this.webSocket = new AudioWebSocket(this.sendFactory, connectWebSocket.getSessionInfo(),


### PR DESCRIPTION
Fixes #9 

When FredBoat tries to resume Lavalink's session, it will always resend the voice server update. Without this PR, the voice server update would result in a momentary interruption.